### PR TITLE
feat: Add ssh tunnel example

### DIFF
--- a/tunnel.sh
+++ b/tunnel.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -e
+
+USAGE="usage: $0 user@host [command to exec]"
+USER_HOST_PAIR=$1
+
+function main {
+    # See link for services running on the ports below
+    # https://www.ibm.com/support/knowledgecenter/en/ssw_ibm_i_71/rzaii/rzaiiservicesandports.htm
+    I_SVR_PORTS="8470 8471 8472 8473 8474 8475 8476 449 446 9470 9471 9472 9473 9474 9475 9476"
+    PORT_FWD_SSH_OPT=""
+    for port in $I_SVR_PORTS
+    do
+        # ssh -L [LOCAL_IP:]LOCAL_PORT:DESTINATION:DESTINATION_PORT
+        PORT_FWD_SSH_OPT="$PORT_FWD_SSH_OPT -L 0.0.0.0:$port:127.0.0.1:$port "
+    done
+    ssh -o StrictHostKeyChecking=no $PORT_FWD_SSH_OPT -f -N $USER_HOST_PAIR
+    exec $*
+}
+
+case "$USER_HOST_PAIR" in
+    *'@'*) # ensure USER_HOST_PAIR contains @
+        shift
+        main $@
+    ;;
+    *)
+        echo "$USAGE"
+        exit -1
+    ;;
+esac
+


### PR DESCRIPTION
This is an example script that establishes port forwarding between remote IBM i system to local ports. Once the tunnel is establish it execs a command given to it.  For example:

```bash 
./tunnel.sh user@host node index.js
```

This will establish the tunnel then exec `node index.js`

This script can be used to establish a link between a container and a remote IBM i system for odbc connections for example. Although All of these ports are not needed by odbc for example they are included in the list.