### PR TITLE
Fix typo and follow shellcheck recommendation for SC2086

### DIFF
--- a/fix_ssh_permissions.sh
+++ b/fix_ssh_permissions.sh
@@ -2,8 +2,8 @@
 # To fix up directory permissions after running ssh-copy-id to copy your keys to IBM i
 # Download and run this script, or copy/paste the following commands into an IBM i shell (preferrably SSH)
 mkdir -p $HOME/.ssh
-chown `/QOpenSys/usr/bib/id -u -n` $HOME
-chown -R `/QOpenSys/usr/bib/id -u -n` $HOME/.ssh
+chown "$(/QOpenSys/usr/bin/id -u -n)" $HOME
+chown -R "$(/QOpenSys/usr/bin/id -u -n)" $HOME/.ssh
 chmod 0755 $HOME
 chmod 0700 $HOME/.ssh
 chmod 0644 $HOME/.ssh/authorized_keys


### PR DESCRIPTION
You had a small, but significant typo in the path to id... :grin: 

And I also changed it to follow a recommendation from the shellcheck verifier - to quote the expression.